### PR TITLE
Number.SetValue() should accept a float instead of int

### DIFF
--- a/internal/services/number.go
+++ b/internal/services/number.go
@@ -16,7 +16,7 @@ type Number struct {
 
 /* Public API */
 
-func (ib Number) SetValue(entityId string, value int) {
+func (ib Number) SetValue(entityId string, value float32) {
 	req := NewBaseServiceRequest(entityId)
 	req.Domain = "number"
 	req.Service = "set_value"


### PR DESCRIPTION
I personally use a `number` entity to control boiler's power with values between 0.0 and 1.0.