### PR TITLE
Avoid panic on disconnect, provide connection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The general flow is
 import ga "saml.dev/gome-assistant"
 
 // replace with IP and port of your Home Assistant installation
-app := ga.NewApp("0.0.0.0:8123")
+app, err := ga.NewApp("0.0.0.0:8123")
 
 // create automations here (see next sections)
 

--- a/app.go
+++ b/app.go
@@ -263,9 +263,12 @@ func (a *App) Start() {
 	// entity listeners and event listeners
 	elChan := make(chan ws.ChanMsg)
 	go ws.ListenWebsocket(a.conn, a.ctx, elChan)
-	var msg ws.ChanMsg
+
 	for {
-		msg = <-elChan
+		msg, ok := <-elChan
+		if !ok {
+			break
+		}
 		if a.entityListenersId == msg.Id {
 			go callEntityListeners(a, msg.Raw)
 		} else {

--- a/example/example.go
+++ b/example/example.go
@@ -10,11 +10,16 @@ import (
 )
 
 func main() {
-	app := ga.NewApp(ga.NewAppRequest{
+	app, err := ga.NewApp(ga.NewAppRequest{
 		IpAddress:        "192.168.86.67", // Replace with your Home Assistant IP Address
 		HAAuthToken:      os.Getenv("HA_AUTH_TOKEN"),
 		HomeZoneEntityId: "zone.home",
 	})
+
+	if err != nil {
+		log.Fatalln("Error connecting to HASS:", err)
+	}
+
 	defer app.Cleanup()
 
 	pantryDoor := ga.

--- a/internal/websocket/reader.go
+++ b/internal/websocket/reader.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"context"
 	"encoding/json"
+	"log"
 
 	"github.com/gorilla/websocket"
 )
@@ -20,7 +21,14 @@ type ChanMsg struct {
 
 func ListenWebsocket(conn *websocket.Conn, ctx context.Context, c chan ChanMsg) {
 	for {
-		bytes, _ := ReadMessage(conn, ctx)
+		bytes, err := ReadMessage(conn, ctx)
+
+		if err != nil {
+			log.Default().Println("Error reading from websocket:", err)
+			close(c)
+			break
+		}
+
 		base := BaseMessage{}
 		json.Unmarshal(bytes, &base)
 		chanMsg := ChanMsg{


### PR DESCRIPTION
Changes:
* No panic when HASS connection is lost.
* No Fatal() when HASS connect fails, return the error instead.
* Have a distinct error constant for auth failures, as the apps may want to react differently to these.

I need this so that my app can cleanly recover when HASS gets restarted.

Introduces a breaking change to the API, but the example and readme are also updated.