### PR TITLE
Fix a crash in State.getLatLong()

### DIFF
--- a/app.go
+++ b/app.go
@@ -98,7 +98,10 @@ func NewApp(request NewAppRequest) (*App, error) {
 
 	wsWriter := &ws.WebsocketWriter{Conn: conn}
 	service := newService(wsWriter, ctx, httpClient)
-	state := newState(httpClient, request.HomeZoneEntityId)
+	state, err := newState(httpClient, request.HomeZoneEntityId)
+	if err != nil {
+		return nil, err
+	}
 
 	return &App{
 		conn:            conn,


### PR DESCRIPTION
I don't know the exact cause, but I've seen some occasional crashes like this, probably due to hass being restarted at that moment:

```
panic: interface conversion: interface {} is nil, not float64
```