### PR TITLE
feat: support secure connections

### DIFF
--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -16,8 +16,24 @@ type HttpClient struct {
 }
 
 func NewHttpClient(ip, port, token string) *HttpClient {
-	url := fmt.Sprintf("http://%s:%s/api", ip, port)
-	return &HttpClient{url, token}
+	return ClientFromUri(
+		fmt.Sprintf("http://%s:%s/api", ip, port),
+		token,
+	)
+}
+
+func NewHttpsClient(ip, port, token string) *HttpClient {
+	return ClientFromUri(
+		fmt.Sprintf("https://%s:%s/api", ip, port),
+		token,
+	)
+}
+
+func ClientFromUri(uri, token string) *HttpClient {
+	return &HttpClient{
+		uri,
+		token,
+	}
 }
 
 func (c *HttpClient) GetState(entityId string) ([]byte, error) {

--- a/internal/websocket/websocket.go
+++ b/internal/websocket/websocket.go
@@ -50,14 +50,24 @@ func ReadMessage(conn *websocket.Conn, ctx context.Context) ([]byte, error) {
 }
 
 func SetupConnection(ip, port, authToken string) (*websocket.Conn, context.Context, context.CancelFunc, error) {
+	uri := fmt.Sprintf("ws:///%s:%s/api/websocket", ip, port)
+	return ConnectionFromUri(uri, authToken)
+}
+
+func SetupSecureConnection(ip, port, authToken string) (*websocket.Conn, context.Context, context.CancelFunc, error) {
+	uri := fmt.Sprintf("wss://%s:%s/api/websocket", ip, port)
+	return ConnectionFromUri(uri, authToken)
+}
+
+func ConnectionFromUri(uri, authToken string) (*websocket.Conn, context.Context, context.CancelFunc, error) {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), time.Second*3)
 
 	// Init websocket connection
 	dialer := websocket.DefaultDialer
-	conn, _, err := dialer.DialContext(ctx, fmt.Sprintf("ws://%s:%s/api/websocket", ip, port), nil)
+	conn, _, err := dialer.DialContext(ctx, uri, nil)
 	if err != nil {
 		ctxCancel()
-		slog.Error("Failed to connect to websocket at ws://%s:%s/api/websocket. Check IP address and port\n", ip, port)
+		slog.Error("Failed to connect to websocket. Check URI\n", "uri", uri)
 		return nil, nil, nil, err
 	}
 


### PR DESCRIPTION
I was playing around with gome-assistant, because I really like the idea of having full control of my automations, with type safety and proper programming tools, so I was very happy to find this project!

My home-assistant instance (container) sits behind a TLS-enabled traefik reverse-proxy, so websocket and REST connections were failing.
I _could_ put the containers on the same network to get them to talk via insecure `http://` and `ws://`, but right now they would be isolated.
Additionally, for non-containerized workload it might also be beneficial to support secure connections.

This PR allows connections via `https` and `wss` respectively.
I tried to make sure to implement the changes backwards compatible, to not break the internal API. The change set would be a lot more concise without it.

Let me know what you think.