### PR TITLE
Add a way to fire Home Assistant events

### DIFF
--- a/internal/services/event.go
+++ b/internal/services/event.go
@@ -1,0 +1,39 @@
+package services
+
+import (
+	"context"
+
+	"saml.dev/gome-assistant/internal"
+	ws "saml.dev/gome-assistant/internal/websocket"
+)
+
+type Event struct {
+	conn *ws.WebsocketWriter
+	ctx  context.Context
+}
+
+// Fire an event
+type FireEventRequest struct {
+	Id        int64          `json:"id"`
+	Type      string         `json:"type"` // always set to "fire_event"
+	EventType string         `json:"event_type"`
+	EventData map[string]any `json:"event_data,omitempty"`
+}
+
+/* Public API */
+
+// Fire an event. Takes an event type and an optional map that is sent
+// as `event_data`.
+func (e Event) Fire(eventType string, eventData ...map[string]any) {
+	req := FireEventRequest{
+		Id:   internal.GetId(),
+		Type: "fire_event",
+	}
+
+	req.EventType = eventType
+	if len(eventData) != 0 {
+		req.EventData = eventData[0]
+	}
+
+	e.conn.WriteMessage(req, e.ctx)
+}

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -21,6 +21,7 @@ func BuildService[
 		InputDatetime |
 		InputText |
 		InputNumber |
+		Event |
 		Notify |
 		Number |
 		Scene |

--- a/service.go
+++ b/service.go
@@ -22,6 +22,7 @@ type Service struct {
 	InputText         *services.InputText
 	InputDatetime     *services.InputDatetime
 	InputNumber       *services.InputNumber
+	Event             *services.Event
 	Notify            *services.Notify
 	Number            *services.Number
 	Scene             *services.Scene
@@ -46,6 +47,7 @@ func newService(conn *ws.WebsocketWriter, ctx context.Context, httpClient *http.
 		InputText:         services.BuildService[services.InputText](conn, ctx),
 		InputDatetime:     services.BuildService[services.InputDatetime](conn, ctx),
 		InputNumber:       services.BuildService[services.InputNumber](conn, ctx),
+		Event:             services.BuildService[services.Event](conn, ctx),
 		Notify:            services.BuildService[services.Notify](conn, ctx),
 		Number:            services.BuildService[services.Number](conn, ctx),
 		Scene:             services.BuildService[services.Scene](conn, ctx),


### PR DESCRIPTION
I'm just a beginner at home automation, trying to get my existing IKEA kit functioning correctly with Home Assistant. I was testing out this package as a way to write automations in Go. (Go seems perfect for the job!) It seems to me that it would be useful feature to be able to fire events into Home Assistant. So this PR adds a simple way of doing that.

In case anybody's curious, my goal is to write some Go code to translate the wacky and inconsistent events that Styrbar remotes emit into more regular events such as those consumed by [Awesome HA Blueprints hooks](https://epmatt.github.io/awesome-ha-blueprints/docs/controllers-hooks-ecosystem), including long-press and release events for all of the buttons and also optional synthetic double-click events. The basic translation is working now (using the modification in this PR) and my next step is to try to get my Go program running on my Raspberry Pi-based HA controller.
