### PR TITLE
Parse URL and pass it to clients

### DIFF
--- a/example/example.go
+++ b/example/example.go
@@ -1,4 +1,4 @@
-package example
+package main
 
 import (
 	"encoding/json"
@@ -11,12 +11,12 @@ import (
 
 func main() {
 	app, err := ga.NewApp(ga.NewAppRequest{
-		IpAddress:        "192.168.86.67", // Replace with your Home Assistant IP Address
+		URL:              "http://192.168.86.67:8123", // Replace with your Home Assistant IP Address
 		HAAuthToken:      os.Getenv("HA_AUTH_TOKEN"),
 		HomeZoneEntityId: "zone.home",
 	})
 	if err != nil {
-		slog.Error("Error connecting to HASS:", err)
+		slog.Error("Error connecting to HASS:", "error", err)
 		os.Exit(1)
 	}
 

--- a/example/example_live_test.go
+++ b/example/example_live_test.go
@@ -1,4 +1,4 @@
-package example
+package main
 
 import (
 	"log/slog"
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/yaml.v3"
+
 	ga "saml.dev/gome-assistant"
 )
 
@@ -52,13 +53,13 @@ func (s *MySuite) SetupSuite() {
 
 	configFile, err := os.ReadFile("./config.yaml")
 	if err != nil {
-		slog.Error("Error reading config file", err)
+		slog.Error("Error reading config file", "error", err)
 	}
 	s.config = &Config{}
 	// either env var or config file can be used to set HA auth. token
 	s.config.Hass.HAAuthToken = os.Getenv("HA_AUTH_TOKEN")
 	if err := yaml.Unmarshal(configFile, s.config); err != nil {
-		slog.Error("Error unmarshalling config file", err)
+		slog.Error("Error unmarshalling config file", "error", err)
 	}
 
 	s.app, err = ga.NewApp(ga.NewAppRequest{
@@ -67,7 +68,7 @@ func (s *MySuite) SetupSuite() {
 		HomeZoneEntityId: s.config.Hass.HomeZoneEntityId,
 	})
 	if err != nil {
-		slog.Error("Failed to createw new app", err)
+		slog.Error("Failed to create new app", "error", err)
 		s.T().FailNow()
 	}
 
@@ -135,7 +136,7 @@ func (s *MySuite) dailyScheduleCallback(se *ga.Service, st ga.State) {
 func getEntityState(s *MySuite, entityId string) string {
 	state, err := s.app.GetState().Get(entityId)
 	if err != nil {
-		slog.Error("Error getting entity state", err)
+		slog.Error("Error getting entity state", "error", err)
 		s.T().FailNow()
 	}
 	slog.Info("State of entity", "state", state.State)

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,6 +1,6 @@
 module example
 
-go 1.21
+go 1.23
 
 require (
 	github.com/golang-cz/devslog v0.0.8

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -5,9 +5,9 @@ package http
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 )
 
 type HttpClient struct {
@@ -15,24 +15,19 @@ type HttpClient struct {
 	token string
 }
 
-func NewHttpClient(ip, port, token string) *HttpClient {
-	return ClientFromUri(
-		fmt.Sprintf("http://%s:%s/api", ip, port),
-		token,
-	)
-}
+func NewHttpClient(url *url.URL, token string) *HttpClient {
+	// Shallow copy the URL to avoid modifying the original
+	u := *url
+	if u.Scheme == "ws" {
+		u.Scheme = "http"
+	}
+	if u.Scheme == "wss" {
+		u.Scheme = "https"
+	}
 
-func NewHttpsClient(ip, port, token string) *HttpClient {
-	return ClientFromUri(
-		fmt.Sprintf("https://%s:%s/api", ip, port),
-		token,
-	)
-}
-
-func ClientFromUri(uri, token string) *HttpClient {
 	return &HttpClient{
-		uri,
-		token,
+		url:   u.String(),
+		token: token,
 	}
 }
 

--- a/state.go
+++ b/state.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang-module/carbon"
+
 	"saml.dev/gome-assistant/internal/http"
 )
 


### PR DESCRIPTION
Right now, this SDK only works with IP:Port.
I'm however running on https://home.example.com and need https or wss and an implicit port 443.

Using net/url should be the best option.
