### PR TITLE
Tweak some types in `PriorityQueue`

### DIFF
--- a/internal/priorityqueue/priorityqueue.go
+++ b/internal/priorityqueue/priorityqueue.go
@@ -8,14 +8,14 @@ import (
 // PriorityQueue represents the queue
 type PriorityQueue struct {
 	itemHeap *itemHeap
-	lookup   map[any]*item
+	lookup   map[string]*item
 }
 
 // New initializes an empty priority queue.
 func New() PriorityQueue {
 	return PriorityQueue{
 		itemHeap: &itemHeap{},
-		lookup:   make(map[any]*item),
+		lookup:   make(map[string]*item),
 	}
 }
 


### PR DESCRIPTION
This is just a trivial little cleanup.

* Modernize `interface{}`→ `any` (this also gets rid of some linter warnings).
* Tighten up the type of `PriorityQueue.lookup`.
