### PR TITLE
ensure write operations are done on a pointer

### DIFF
--- a/interval.go
+++ b/interval.go
@@ -168,8 +168,12 @@ func (i Interval) run(ctx context.Context, app *App) {
 		}
 
 		i.maybeRunCallback(app)
-		i.nextRunTime = i.nextRunTime.Add(i.frequency)
+		i.updateNextRunTime()
 	}
+}
+
+func (i *Interval) updateNextRunTime() {
+	i.nextRunTime = i.nextRunTime.Add(i.frequency)
 }
 
 func (i Interval) maybeRunCallback(app *App) {

--- a/schedule.go
+++ b/schedule.go
@@ -198,7 +198,7 @@ func (s DailySchedule) maybeRunCallback(app *App) {
 
 // updateNextRunTime updates `s.nextRunTime` to the next time that `s`
 // should run.
-func (s DailySchedule) updateNextRunTime(app *App) {
+func (s *DailySchedule) updateNextRunTime(app *App) {
 	if s.isSunrise || s.isSunset {
 		var nextSunTime carbon.Carbon
 		// "0s" is default value


### PR DESCRIPTION
DailySchedule.updateNextRunTime took a copy and tried to write to it, which caused the loop to run infinitely since the next run time was never updated. This led to runaway memory usage and crashed my linux machine.

Interval did not have the problem even though it is also writing to a copy, because it does so in the same method where it reads. I moved that write to a separate method to prevent this same bug from being accidentally introduced in the future.

Fixes #44.