### PR TITLE
Use Go convention for capitalization of "ID" in identifiers: `Id`→ `ID`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ import ga "saml.dev/gome-assistant"
 app, err := ga.NewApp(ga.NewAppRequest{
 	URL:              "http://192.168.1.123:8123",
 	HAAuthToken:      os.Getenv("HA_AUTH_TOKEN"),
-	HomeZoneEntityId: "zone.home",
+	HomeZoneEntityID: "zone.home",
 })
 
 // create automations here (see next sections)
@@ -161,7 +161,7 @@ func myFunc(se *ga.Service, st *ga.State) {
 Entity Listeners are used to respond to entities changing state. The simplest entity listener looks like:
 
 ```go
-etl := ga.NewEntityListener().EntityIds("binary_sensor.front_door").Call(myFunc).Build()
+etl := ga.NewEntityListener().EntityIDs("binary_sensor.front_door").Call(myFunc).Build()
 ```
 
 Entity listeners have other functions to change the behavior.

--- a/app.go
+++ b/app.go
@@ -78,10 +78,10 @@ type NewAppRequest struct {
 	HAAuthToken string
 
 	// Required
-	// EntityId of the zone representing your home e.g. "zone.home".
+	// EntityID of the zone representing your home e.g. "zone.home".
 	// Used to pull latitude/longitude from Home Assistant
 	// to calculate sunset/sunrise times.
-	HomeZoneEntityId string
+	HomeZoneEntityID string
 
 	// Optional
 	// Whether to use secure connections for http and websockets.
@@ -125,8 +125,8 @@ func NewApp(ctx context.Context, request NewAppRequest) (*App, error) {
 	}
 
 	// Set default home zone if not provided
-	if request.HomeZoneEntityId == "" {
-		request.HomeZoneEntityId = "zone.home"
+	if request.HomeZoneEntityID == "" {
+		request.HomeZoneEntityID = "zone.home"
 	}
 
 	baseURL := &url.URL{}
@@ -160,7 +160,7 @@ func NewApp(ctx context.Context, request NewAppRequest) (*App, error) {
 
 	httpClient := http.NewHttpClient(baseURL, request.HAAuthToken)
 
-	state, err := newState(httpClient, request.HomeZoneEntityId)
+	state, err := newState(httpClient, request.HomeZoneEntityID)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func NewApp(ctx context.Context, request NewAppRequest) (*App, error) {
 	app.service = newService(&app)
 
 	// Validate home zone
-	if err := validateHomeZone(state, request.HomeZoneEntityId); err != nil {
+	if err := validateHomeZone(state, request.HomeZoneEntityID); err != nil {
 		return nil, err
 	}
 
@@ -239,7 +239,7 @@ func (app *App) registerEntityListener(etl EntityListener) {
 		panic(ErrInvalidArgs)
 	}
 
-	for _, entity := range etl.entityIds {
+	for _, entity := range etl.entityIDs {
 		app.entityListeners[entity] = append(app.entityListeners[entity], &etl)
 	}
 }
@@ -346,7 +346,7 @@ func (app *App) Start() {
 
 				etl.runOnStartupCompleted = true
 				go etl.callback(app.service, app.state, EntityData{
-					TriggerEntityId: eid,
+					TriggerEntityID: eid,
 					FromState:       entityState.State,
 					FromAttributes:  entityState.Attributes,
 					ToState:         entityState.State,

--- a/call.go
+++ b/call.go
@@ -10,7 +10,7 @@ func (app *App) Call(req services.BaseServiceRequest) error {
 
 	return app.conn.Send(
 		func(lc websocket.LockedConn) error {
-			req.Id = lc.NextMessageID()
+			req.ID = lc.NextMessageID()
 			return lc.SendMessage(req)
 		},
 	)

--- a/cmd/example/example.go
+++ b/cmd/example/example.go
@@ -25,7 +25,7 @@ func main() {
 		ga.NewAppRequest{
 			URL:              "http://192.168.86.67:8123", // Replace with your Home Assistant URL
 			HAAuthToken:      os.Getenv("HA_AUTH_TOKEN"),
-			HomeZoneEntityId: "zone.home",
+			HomeZoneEntityID: "zone.home",
 		},
 	)
 	if err != nil {
@@ -37,7 +37,7 @@ func main() {
 
 	pantryDoor := ga.
 		NewEntityListener().
-		EntityIds(entities.BinarySensor.PantryDoor). // Use generated entity constant
+		EntityIDs(entities.BinarySensor.PantryDoor). // Use generated entity constant
 		Call(pantryLights).
 		Build()
 

--- a/cmd/example/example_live_test.go
+++ b/cmd/example/example_live_test.go
@@ -33,10 +33,10 @@ type (
 			HAAuthToken      string `yaml:"token"`
 			IpAddress        string `yaml:"address"`
 			Port             string `yaml:"port"`
-			HomeZoneEntityId string `yaml:"zone"`
+			HomeZoneEntityID string `yaml:"zone"`
 		}
 		Entities struct {
-			LightEntityId string `yaml:"light_entity_id"`
+			LightEntityID string `yaml:"light_entity_id"`
 		}
 	}
 )
@@ -72,7 +72,7 @@ func (s *MySuite) SetupSuite() {
 		ga.NewAppRequest{
 			HAAuthToken:      s.config.Hass.HAAuthToken,
 			IpAddress:        s.config.Hass.IpAddress,
-			HomeZoneEntityId: s.config.Hass.HomeZoneEntityId,
+			HomeZoneEntityID: s.config.Hass.HomeZoneEntityID,
 		},
 	)
 	if err != nil {
@@ -81,10 +81,10 @@ func (s *MySuite) SetupSuite() {
 	}
 
 	// Register all automations
-	entityId := s.config.Entities.LightEntityId
-	if entityId != "" {
+	entityID := s.config.Entities.LightEntityID
+	if entityID != "" {
 		s.suiteCtx.entityCallbackInvoked.Store(false)
-		etl := ga.NewEntityListener().EntityIds(entityId).Call(s.entityCallback).Build()
+		etl := ga.NewEntityListener().EntityIDs(entityID).Call(s.entityCallback).Build()
 		s.app.RegisterEntityListeners(etl)
 	}
 
@@ -106,14 +106,14 @@ func (s *MySuite) TearDownSuite() {
 
 // Basic test of light toggle service and entity listener
 func (s *MySuite) TestLightService() {
-	entityId := s.config.Entities.LightEntityId
+	entityID := s.config.Entities.LightEntityID
 
-	if entityId != "" {
-		initState := getEntityState(s, entityId)
-		s.app.GetService().Light.Toggle(entityId)
+	if entityID != "" {
+		initState := getEntityState(s, entityID)
+		s.app.GetService().Light.Toggle(entityID)
 
 		assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
-			newState := getEntityState(s, entityId)
+			newState := getEntityState(s, entityID)
 			assert.NotEqual(c, initState, newState)
 			assert.True(c, s.suiteCtx.entityCallbackInvoked.Load())
 		}, 10*time.Second, 1*time.Second, "State of light entity did not change or callback was not invoked")
@@ -131,7 +131,7 @@ func (s *MySuite) TestSchedule() {
 
 // Capture event after light entity state has changed
 func (s *MySuite) entityCallback(se *ga.Service, st ga.State, e ga.EntityData) {
-	slog.Info("Entity callback called.", "entity id", e.TriggerEntityId, "from state", e.FromState, "to state", e.ToState)
+	slog.Info("Entity callback called.", "entity id", e.TriggerEntityID, "from state", e.FromState, "to state", e.ToState)
 	s.suiteCtx.entityCallbackInvoked.Store(true)
 }
 
@@ -141,8 +141,8 @@ func (s *MySuite) dailyScheduleCallback(se *ga.Service, st ga.State) {
 	s.suiteCtx.dailyScheduleCallbackInvoked.Store(true)
 }
 
-func getEntityState(s *MySuite, entityId string) string {
-	state, err := s.app.GetState().Get(entityId)
+func getEntityState(s *MySuite, entityID string) string {
+	state, err := s.app.GetState().Get(entityID)
 	if err != nil {
 		slog.Error("Error getting entity state", "error", err)
 		s.T().FailNow()

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -18,7 +18,7 @@ import (
 type Config struct {
 	URL              string   `yaml:"url"`
 	HAAuthToken      string   `yaml:"ha_auth_token"`
-	HomeZoneEntityId string   `yaml:"home_zone_entity_id,omitempty"` // Now optional
+	HomeZoneEntityID string   `yaml:"home_zone_entity_id,omitempty"` // Now optional
 	IncludeDomains   []string `yaml:"include_domains,omitempty"`     // Optional list of domains to include
 	ExcludeDomains   []string `yaml:"exclude_domains,omitempty"`     // Optional list of domains to exclude
 }
@@ -96,8 +96,8 @@ func validateHomeZone(state ga.State, entityID string) error {
 
 // generate creates the entities.go file with constants for all Home Assistant entities
 func generate(ctx context.Context, config Config) error {
-	if config.HomeZoneEntityId == "" {
-		config.HomeZoneEntityId = "zone.home"
+	if config.HomeZoneEntityID == "" {
+		config.HomeZoneEntityID = "zone.home"
 	}
 
 	app, err := ga.NewApp(
@@ -105,7 +105,7 @@ func generate(ctx context.Context, config Config) error {
 		ga.NewAppRequest{
 			URL:              config.URL,
 			HAAuthToken:      config.HAAuthToken,
-			HomeZoneEntityId: config.HomeZoneEntityId,
+			HomeZoneEntityID: config.HomeZoneEntityID,
 		},
 	)
 	if err != nil {
@@ -114,7 +114,7 @@ func generate(ctx context.Context, config Config) error {
 	defer app.Cleanup()
 
 	// Validate that the home zone exists before proceeding
-	if err := validateHomeZone(app.GetState(), config.HomeZoneEntityId); err != nil {
+	if err := validateHomeZone(app.GetState(), config.HomeZoneEntityID); err != nil {
 		return fmt.Errorf("invalid home zone: %w", err)
 	}
 

--- a/entitylistener.go
+++ b/entitylistener.go
@@ -11,7 +11,7 @@ import (
 )
 
 type EntityListener struct {
-	entityIds []string
+	entityIDs []string
 	callback  EntityListenerCallback
 	fromState string
 	toState   string
@@ -37,7 +37,7 @@ type EntityListener struct {
 type EntityListenerCallback func(*Service, State, EntityData)
 
 type EntityData struct {
-	TriggerEntityId string
+	TriggerEntityID string
 	FromState       string
 	FromAttributes  map[string]any
 	ToState         string
@@ -80,11 +80,11 @@ type elBuilder1 struct {
 	entityListener EntityListener
 }
 
-func (b elBuilder1) EntityIds(entityIds ...string) elBuilder2 {
-	if len(entityIds) == 0 {
-		panic("must pass at least one entityId to EntityIds()")
+func (b elBuilder1) EntityIDs(EntityIDs ...string) elBuilder2 {
+	if len(EntityIDs) == 0 {
+		panic("must pass at least one entityID to EntityIDs()")
 	} else {
-		b.entityListener.entityIds = entityIds
+		b.entityListener.entityIDs = EntityIDs
 	}
 	return elBuilder2(b)
 }
@@ -156,15 +156,15 @@ func (b elBuilder3) RunOnStartup() elBuilder3 {
 }
 
 /*
-Enable this listener only when the current state of {entityId} matches {state}.
+Enable this listener only when the current state of {entityID} matches {state}.
 If there is a network error while retrieving state, the listener runs if {runOnNetworkError} is true.
 */
-func (b elBuilder3) EnabledWhen(entityId, state string, runOnNetworkError bool) elBuilder3 {
-	if entityId == "" {
-		panic(fmt.Sprintf("entityId is empty in EnabledWhen entityId='%s' state='%s'", entityId, state))
+func (b elBuilder3) EnabledWhen(entityID, state string, runOnNetworkError bool) elBuilder3 {
+	if entityID == "" {
+		panic(fmt.Sprintf("entityID is empty in EnabledWhen entityID='%s' state='%s'", entityID, state))
 	}
 	i := internal.EnabledDisabledInfo{
-		Entity:     entityId,
+		Entity:     entityID,
 		State:      state,
 		RunOnError: runOnNetworkError,
 	}
@@ -173,15 +173,15 @@ func (b elBuilder3) EnabledWhen(entityId, state string, runOnNetworkError bool) 
 }
 
 /*
-Disable this listener when the current state of {entityId} matches {state}.
+Disable this listener when the current state of {entityID} matches {state}.
 If there is a network error while retrieving state, the listener runs if {runOnNetworkError} is true.
 */
-func (b elBuilder3) DisabledWhen(entityId, state string, runOnNetworkError bool) elBuilder3 {
-	if entityId == "" {
-		panic(fmt.Sprintf("entityId is empty in EnabledWhen entityId='%s' state='%s'", entityId, state))
+func (b elBuilder3) DisabledWhen(entityID, state string, runOnNetworkError bool) elBuilder3 {
+	if entityID == "" {
+		panic(fmt.Sprintf("entityID is empty in EnabledWhen entityID='%s' state='%s'", entityID, state))
 	}
 	i := internal.EnabledDisabledInfo{
-		Entity:     entityId,
+		Entity:     entityID,
 		State:      state,
 		RunOnError: runOnNetworkError,
 	}
@@ -258,7 +258,7 @@ func (app *App) callEntityListeners(msgBytes []byte) {
 	}
 
 	entityData := EntityData{
-		TriggerEntityId: eid,
+		TriggerEntityID: eid,
 		FromState:       data.OldState.State,
 		FromAttributes:  data.OldState.Attributes,
 		ToState:         data.NewState.State,

--- a/eventListener.go
+++ b/eventListener.go
@@ -95,15 +95,15 @@ func (b eventListenerBuilder3) ExceptionRange(start, end time.Time) eventListene
 }
 
 /*
-Enable this listener only when the current state of {entityId} matches {state}.
+Enable this listener only when the current state of {entityID} matches {state}.
 If there is a network error while retrieving state, the listener runs if {runOnNetworkError} is true.
 */
-func (b eventListenerBuilder3) EnabledWhen(entityId, state string, runOnNetworkError bool) eventListenerBuilder3 {
-	if entityId == "" {
-		panic(fmt.Sprintf("entityId is empty in eventListener EnabledWhen entityId='%s' state='%s' runOnNetworkError='%t'", entityId, state, runOnNetworkError))
+func (b eventListenerBuilder3) EnabledWhen(entityID, state string, runOnNetworkError bool) eventListenerBuilder3 {
+	if entityID == "" {
+		panic(fmt.Sprintf("entityID is empty in eventListener EnabledWhen entityID='%s' state='%s' runOnNetworkError='%t'", entityID, state, runOnNetworkError))
 	}
 	i := internal.EnabledDisabledInfo{
-		Entity:     entityId,
+		Entity:     entityID,
 		State:      state,
 		RunOnError: runOnNetworkError,
 	}
@@ -112,15 +112,15 @@ func (b eventListenerBuilder3) EnabledWhen(entityId, state string, runOnNetworkE
 }
 
 /*
-Disable this listener when the current state of {entityId} matches {state}.
+Disable this listener when the current state of {entityID} matches {state}.
 If there is a network error while retrieving state, the listener runs if {runOnNetworkError} is true.
 */
-func (b eventListenerBuilder3) DisabledWhen(entityId, state string, runOnNetworkError bool) eventListenerBuilder3 {
-	if entityId == "" {
-		panic(fmt.Sprintf("entityId is empty in eventListener EnabledWhen entityId='%s' state='%s' runOnNetworkError='%t'", entityId, state, runOnNetworkError))
+func (b eventListenerBuilder3) DisabledWhen(entityID, state string, runOnNetworkError bool) eventListenerBuilder3 {
+	if entityID == "" {
+		panic(fmt.Sprintf("entityID is empty in eventListener EnabledWhen entityID='%s' state='%s' runOnNetworkError='%t'", entityID, state, runOnNetworkError))
 	}
 	i := internal.EnabledDisabledInfo{
-		Entity:     entityId,
+		Entity:     entityID,
 		State:      state,
 		RunOnError: runOnNetworkError,
 	}

--- a/fire_event.go
+++ b/fire_event.go
@@ -6,7 +6,7 @@ func (app *App) FireEvent(eventType string, eventData map[string]any) error {
 	return app.conn.Send(
 		func(lc websocket.LockedConn) error {
 			req := FireEventRequest{
-				Id:        lc.NextMessageID(),
+				ID:        lc.NextMessageID(),
 				Type:      "fire_event",
 				EventType: eventType,
 				EventData: eventData,
@@ -19,7 +19,7 @@ func (app *App) FireEvent(eventType string, eventData map[string]any) error {
 
 // Fire an event
 type FireEventRequest struct {
-	Id        int64          `json:"id"`
+	ID        int64          `json:"id"`
 	Type      string         `json:"type"` // always set to "fire_event"
 	EventType string         `json:"event_type"`
 	EventData map[string]any `json:"event_data,omitempty"`

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -32,8 +32,8 @@ func NewHttpClient(url *url.URL, token string) *HttpClient {
 	}
 }
 
-func (c *HttpClient) GetState(entityId string) ([]byte, error) {
-	resp, err := get(c.url+"/states/"+entityId, c.token)
+func (c *HttpClient) GetState(entityID string) ([]byte, error) {
+	resp, err := get(c.url+"/states/"+entityID, c.token)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/adaptive_lighting.go
+++ b/internal/services/adaptive_lighting.go
@@ -9,15 +9,15 @@ type AdaptiveLighting struct {
 /* Public API */
 
 // Set manual control for an adaptive lighting entity.
-func (al AdaptiveLighting) SetManualControl(entityId string, enabled bool) error {
+func (al AdaptiveLighting) SetManualControl(entityID string, enabled bool) error {
 	req := BaseServiceRequest{
 		Domain:  "adaptive_lighting",
 		Service: "set_manual_control",
 		ServiceData: map[string]any{
-			"entity_id":      entityId,
+			"entity_id":      entityID,
 			"manual_control": enabled,
 		},
-		Target: Entity(entityId),
+		Target: Entity(entityID),
 	}
 
 	return al.api.Call(req)

--- a/internal/services/alarm_control_panel.go
+++ b/internal/services/alarm_control_panel.go
@@ -9,13 +9,13 @@ type AlarmControlPanel struct {
 /* Public API */
 
 // Send the alarm the command for arm away.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (acp AlarmControlPanel) ArmAway(entityId string, serviceData ...map[string]any) error {
+func (acp AlarmControlPanel) ArmAway(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "alarm_control_panel",
 		Service: "alarm_arm_away",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -25,13 +25,13 @@ func (acp AlarmControlPanel) ArmAway(entityId string, serviceData ...map[string]
 }
 
 // Send the alarm the command for arm away.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (acp AlarmControlPanel) ArmWithCustomBypass(entityId string, serviceData ...map[string]any) error {
+func (acp AlarmControlPanel) ArmWithCustomBypass(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "alarm_control_panel",
 		Service: "alarm_arm_custom_bypass",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -41,13 +41,13 @@ func (acp AlarmControlPanel) ArmWithCustomBypass(entityId string, serviceData ..
 }
 
 // Send the alarm the command for arm home.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (acp AlarmControlPanel) ArmHome(entityId string, serviceData ...map[string]any) error {
+func (acp AlarmControlPanel) ArmHome(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "alarm_control_panel",
 		Service: "alarm_arm_home",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -57,13 +57,13 @@ func (acp AlarmControlPanel) ArmHome(entityId string, serviceData ...map[string]
 }
 
 // Send the alarm the command for arm night.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (acp AlarmControlPanel) ArmNight(entityId string, serviceData ...map[string]any) error {
+func (acp AlarmControlPanel) ArmNight(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "alarm_control_panel",
 		Service: "alarm_arm_night",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -73,13 +73,13 @@ func (acp AlarmControlPanel) ArmNight(entityId string, serviceData ...map[string
 }
 
 // Send the alarm the command for arm vacation.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (acp AlarmControlPanel) ArmVacation(entityId string, serviceData ...map[string]any) error {
+func (acp AlarmControlPanel) ArmVacation(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "alarm_control_panel",
 		Service: "alarm_arm_vacation",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -89,13 +89,13 @@ func (acp AlarmControlPanel) ArmVacation(entityId string, serviceData ...map[str
 }
 
 // Send the alarm the command for disarm.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (acp AlarmControlPanel) Disarm(entityId string, serviceData ...map[string]any) error {
+func (acp AlarmControlPanel) Disarm(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "alarm_control_panel",
 		Service: "alarm_disarm",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -105,13 +105,13 @@ func (acp AlarmControlPanel) Disarm(entityId string, serviceData ...map[string]a
 }
 
 // Send the alarm the command for trigger.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (acp AlarmControlPanel) Trigger(entityId string, serviceData ...map[string]any) error {
+func (acp AlarmControlPanel) Trigger(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "alarm_control_panel",
 		Service: "alarm_trigger",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]

--- a/internal/services/climate.go
+++ b/internal/services/climate.go
@@ -12,22 +12,22 @@ type Climate struct {
 
 /* Public API */
 
-func (c Climate) SetFanMode(entityId string, fanMode string) error {
+func (c Climate) SetFanMode(entityID string, fanMode string) error {
 	req := BaseServiceRequest{
 		Domain:      "climate",
 		Service:     "set_fan_mode",
 		ServiceData: map[string]any{"fan_mode": fanMode},
-		Target:      Entity(entityId),
+		Target:      Entity(entityID),
 	}
 	return c.api.Call(req)
 }
 
-func (c Climate) SetTemperature(entityId string, serviceData types.SetTemperatureRequest) error {
+func (c Climate) SetTemperature(entityID string, serviceData types.SetTemperatureRequest) error {
 	req := BaseServiceRequest{
 		Domain:      "climate",
 		Service:     "set_temperature",
 		ServiceData: serviceData.ToJSON(),
-		Target:      Entity(entityId),
+		Target:      Entity(entityID),
 	}
 	return c.api.Call(req)
 }

--- a/internal/services/cover.go
+++ b/internal/services/cover.go
@@ -8,53 +8,53 @@ type Cover struct {
 
 /* Public API */
 
-// Close all or specified cover. Takes an entityId.
-func (c Cover) Close(entityId string) error {
+// Close all or specified cover. Takes an entityID.
+func (c Cover) Close(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "cover",
 		Service: "close_cover",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return c.api.Call(req)
 }
 
-// Close all or specified cover tilt. Takes an entityId.
-func (c Cover) CloseTilt(entityId string) error {
+// Close all or specified cover tilt. Takes an entityID.
+func (c Cover) CloseTilt(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "cover",
 		Service: "close_cover_tilt",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return c.api.Call(req)
 }
 
-// Open all or specified cover. Takes an entityId.
-func (c Cover) Open(entityId string) error {
+// Open all or specified cover. Takes an entityID.
+func (c Cover) Open(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "cover",
 		Service: "open_cover",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return c.api.Call(req)
 }
 
-// Open all or specified cover tilt. Takes an entityId.
-func (c Cover) OpenTilt(entityId string) error {
+// Open all or specified cover tilt. Takes an entityID.
+func (c Cover) OpenTilt(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "cover",
 		Service: "open_cover_tilt",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return c.api.Call(req)
 }
 
-// Move to specific position all or specified cover. Takes an entityId and an optional
+// Move to specific position all or specified cover. Takes an entityID and an optional
 // map that is translated into service_data.
-func (c Cover) SetPosition(entityId string, serviceData ...map[string]any) error {
+func (c Cover) SetPosition(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "cover",
 		Service: "set_cover_position",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -63,11 +63,11 @@ func (c Cover) SetPosition(entityId string, serviceData ...map[string]any) error
 	return c.api.Call(req)
 }
 
-// Move to specific position all or specified cover tilt. Takes an entityId and an optional
+// Move to specific position all or specified cover tilt. Takes an entityID and an optional
 // map that is translated into service_data.
-func (c Cover) SetTiltPosition(entityId string, serviceData ...map[string]any) error {
+func (c Cover) SetTiltPosition(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 		Domain:  "cover",
 		Service: "set_cover_tilt_position",
 	}
@@ -78,42 +78,42 @@ func (c Cover) SetTiltPosition(entityId string, serviceData ...map[string]any) e
 	return c.api.Call(req)
 }
 
-// Stop a cover entity. Takes an entityId.
-func (c Cover) Stop(entityId string) error {
+// Stop a cover entity. Takes an entityID.
+func (c Cover) Stop(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "cover",
 		Service: "stop_cover",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return c.api.Call(req)
 }
 
-// Stop a cover entity tilt. Takes an entityId.
-func (c Cover) StopTilt(entityId string) error {
+// Stop a cover entity tilt. Takes an entityID.
+func (c Cover) StopTilt(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "cover",
 		Service: "stop_cover_tilt",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return c.api.Call(req)
 }
 
-// Toggle a cover open/closed. Takes an entityId.
-func (c Cover) Toggle(entityId string) error {
+// Toggle a cover open/closed. Takes an entityID.
+func (c Cover) Toggle(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "cover",
 		Service: "toggle",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return c.api.Call(req)
 }
 
-// Toggle a cover tilt open/closed. Takes an entityId.
-func (c Cover) ToggleTilt(entityId string) error {
+// Toggle a cover tilt open/closed. Takes an entityID.
+func (c Cover) ToggleTilt(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "cover",
 		Service: "toggle_cover_tilt",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return c.api.Call(req)
 }

--- a/internal/services/homeassistant.go
+++ b/internal/services/homeassistant.go
@@ -4,13 +4,13 @@ type HomeAssistant struct {
 	api API
 }
 
-// TurnOn a Home Assistant entity. Takes an entityId and an optional
+// TurnOn a Home Assistant entity. Takes an entityID and an optional
 // map that is translated into service_data.
-func (ha *HomeAssistant) TurnOn(entityId string, serviceData ...map[string]any) error {
+func (ha *HomeAssistant) TurnOn(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "homeassistant",
 		Service: "turn_on",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -19,13 +19,13 @@ func (ha *HomeAssistant) TurnOn(entityId string, serviceData ...map[string]any) 
 	return ha.api.Call(req)
 }
 
-// Toggle a Home Assistant entity. Takes an entityId and an optional
+// Toggle a Home Assistant entity. Takes an entityID and an optional
 // map that is translated into service_data.
-func (ha *HomeAssistant) Toggle(entityId string, serviceData ...map[string]any) error {
+func (ha *HomeAssistant) Toggle(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "homeassistant",
 		Service: "toggle",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -34,11 +34,11 @@ func (ha *HomeAssistant) Toggle(entityId string, serviceData ...map[string]any) 
 	return ha.api.Call(req)
 }
 
-func (ha *HomeAssistant) TurnOff(entityId string) error {
+func (ha *HomeAssistant) TurnOff(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "homeassistant",
 		Service: "turn_off",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return ha.api.Call(req)
 }

--- a/internal/services/input_boolean.go
+++ b/internal/services/input_boolean.go
@@ -8,29 +8,29 @@ type InputBoolean struct {
 
 /* Public API */
 
-func (ib InputBoolean) TurnOn(entityId string) error {
+func (ib InputBoolean) TurnOn(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "input_boolean",
 		Service: "turn_on",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return ib.api.Call(req)
 }
 
-func (ib InputBoolean) Toggle(entityId string) error {
+func (ib InputBoolean) Toggle(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "input_boolean",
 		Service: "toggle",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return ib.api.Call(req)
 }
 
-func (ib InputBoolean) TurnOff(entityId string) error {
+func (ib InputBoolean) TurnOff(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "input_boolean",
 		Service: "turn_off",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return ib.api.Call(req)
 }

--- a/internal/services/input_button.go
+++ b/internal/services/input_button.go
@@ -8,11 +8,11 @@ type InputButton struct {
 
 /* Public API */
 
-func (ib InputButton) Press(entityId string) error {
+func (ib InputButton) Press(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "input_button",
 		Service: "press",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return ib.api.Call(req)
 }

--- a/internal/services/input_datetime.go
+++ b/internal/services/input_datetime.go
@@ -13,14 +13,14 @@ type InputDatetime struct {
 
 /* Public API */
 
-func (ib InputDatetime) Set(entityId string, value time.Time) error {
+func (ib InputDatetime) Set(entityID string, value time.Time) error {
 	req := BaseServiceRequest{
 		Domain:  "input_datetime",
 		Service: "set_datetime",
 		ServiceData: map[string]any{
 			"timestamp": fmt.Sprint(value.Unix()),
 		},
-		Target: Entity(entityId),
+		Target: Entity(entityID),
 	}
 	return ib.api.Call(req)
 }

--- a/internal/services/input_number.go
+++ b/internal/services/input_number.go
@@ -8,30 +8,30 @@ type InputNumber struct {
 
 /* Public API */
 
-func (ib InputNumber) Set(entityId string, value float32) error {
+func (ib InputNumber) Set(entityID string, value float32) error {
 	req := BaseServiceRequest{
 		Domain:      "input_number",
 		Service:     "set_value",
 		ServiceData: map[string]any{"value": value},
-		Target:      Entity(entityId),
+		Target:      Entity(entityID),
 	}
 	return ib.api.Call(req)
 }
 
-func (ib InputNumber) Increment(entityId string) error {
+func (ib InputNumber) Increment(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "input_number",
 		Service: "increment",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return ib.api.Call(req)
 }
 
-func (ib InputNumber) Decrement(entityId string) error {
+func (ib InputNumber) Decrement(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "input_number",
 		Service: "decrement",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return ib.api.Call(req)
 }

--- a/internal/services/input_text.go
+++ b/internal/services/input_text.go
@@ -8,14 +8,14 @@ type InputText struct {
 
 /* Public API */
 
-func (ib InputText) Set(entityId string, value string) error {
+func (ib InputText) Set(entityID string, value string) error {
 	req := BaseServiceRequest{
 		Domain:  "input_text",
 		Service: "set_value",
 		ServiceData: map[string]any{
 			"value": value,
 		},
-		Target: Entity(entityId),
+		Target: Entity(entityID),
 	}
 	return ib.api.Call(req)
 }

--- a/internal/services/light.go
+++ b/internal/services/light.go
@@ -8,13 +8,13 @@ type Light struct {
 
 /* Public API */
 
-// TurnOn a light entity. Takes an entityId and an optional
+// TurnOn a light entity. Takes an entityID and an optional
 // map that is translated into service_data.
-func (l Light) TurnOn(entityId string, serviceData ...map[string]any) error {
+func (l Light) TurnOn(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "light",
 		Service: "turn_on",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -22,13 +22,13 @@ func (l Light) TurnOn(entityId string, serviceData ...map[string]any) error {
 	return l.api.Call(req)
 }
 
-// Toggle a light entity. Takes an entityId and an optional
+// Toggle a light entity. Takes an entityID and an optional
 // map that is translated into service_data.
-func (l Light) Toggle(entityId string, serviceData ...map[string]any) error {
+func (l Light) Toggle(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "light",
 		Service: "toggle",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -36,11 +36,11 @@ func (l Light) Toggle(entityId string, serviceData ...map[string]any) error {
 	return l.api.Call(req)
 }
 
-func (l Light) TurnOff(entityId string) error {
+func (l Light) TurnOff(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "light",
 		Service: "turn_off",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return l.api.Call(req)
 }

--- a/internal/services/lock.go
+++ b/internal/services/lock.go
@@ -8,13 +8,13 @@ type Lock struct {
 
 /* Public API */
 
-// Lock a lock entity. Takes an entityId and an optional
+// Lock a lock entity. Takes an entityID and an optional
 // map that is translated into service_data.
-func (l Lock) Lock(entityId string, serviceData ...map[string]any) error {
+func (l Lock) Lock(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "lock",
 		Service: "lock",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -22,13 +22,13 @@ func (l Lock) Lock(entityId string, serviceData ...map[string]any) error {
 	return l.api.Call(req)
 }
 
-// Unlock a lock entity. Takes an entityId and an optional
+// Unlock a lock entity. Takes an entityID and an optional
 // map that is translated into service_data.
-func (l Lock) Unlock(entityId string, serviceData ...map[string]any) error {
+func (l Lock) Unlock(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "lock",
 		Service: "unlock",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]

--- a/internal/services/media_player.go
+++ b/internal/services/media_player.go
@@ -9,24 +9,24 @@ type MediaPlayer struct {
 /* Public API */
 
 // Send the media player the command to clear players playlist.
-// Takes an entityId.
-func (mp MediaPlayer) ClearPlaylist(entityId string) error {
+// Takes an entityID.
+func (mp MediaPlayer) ClearPlaylist(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "clear_playlist",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return mp.api.Call(req)
 }
 
 // Group players together. Only works on platforms with support for player groups.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (mp MediaPlayer) Join(entityId string, serviceData ...map[string]any) error {
+func (mp MediaPlayer) Join(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "join",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -35,68 +35,68 @@ func (mp MediaPlayer) Join(entityId string, serviceData ...map[string]any) error
 }
 
 // Send the media player the command for next track.
-// Takes an entityId.
-func (mp MediaPlayer) Next(entityId string) error {
+// Takes an entityID.
+func (mp MediaPlayer) Next(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "media_next_track",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return mp.api.Call(req)
 }
 
 // Send the media player the command for pause.
-// Takes an entityId.
-func (mp MediaPlayer) Pause(entityId string) error {
+// Takes an entityID.
+func (mp MediaPlayer) Pause(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "media_pause",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return mp.api.Call(req)
 }
 
 // Send the media player the command for play.
-// Takes an entityId.
-func (mp MediaPlayer) Play(entityId string) error {
+// Takes an entityID.
+func (mp MediaPlayer) Play(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "media_play",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return mp.api.Call(req)
 }
 
 // Toggle media player play/pause state.
-// Takes an entityId.
-func (mp MediaPlayer) PlayPause(entityId string) error {
+// Takes an entityID.
+func (mp MediaPlayer) PlayPause(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "media_play_pause",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return mp.api.Call(req)
 }
 
 // Send the media player the command for previous track.
-// Takes an entityId.
-func (mp MediaPlayer) Previous(entityId string) error {
+// Takes an entityID.
+func (mp MediaPlayer) Previous(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "media_previous_track",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return mp.api.Call(req)
 }
 
 // Send the media player the command to seek in current playing media.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (mp MediaPlayer) Seek(entityId string, serviceData ...map[string]any) error {
+func (mp MediaPlayer) Seek(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "media_seek",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -105,24 +105,24 @@ func (mp MediaPlayer) Seek(entityId string, serviceData ...map[string]any) error
 }
 
 // Send the media player the stop command.
-// Takes an entityId.
-func (mp MediaPlayer) Stop(entityId string) error {
+// Takes an entityID.
+func (mp MediaPlayer) Stop(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "media_stop",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return mp.api.Call(req)
 }
 
 // Send the media player the command for playing media.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (mp MediaPlayer) PlayMedia(entityId string, serviceData ...map[string]any) error {
+func (mp MediaPlayer) PlayMedia(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "play_media",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -130,13 +130,13 @@ func (mp MediaPlayer) PlayMedia(entityId string, serviceData ...map[string]any) 
 	return mp.api.Call(req)
 }
 
-// Set repeat mode. Takes an entityId and an optional
+// Set repeat mode. Takes an entityID and an optional
 // map that is translated into service_data.
-func (mp MediaPlayer) RepeatSet(entityId string, serviceData ...map[string]any) error {
+func (mp MediaPlayer) RepeatSet(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "repeat_set",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -145,13 +145,13 @@ func (mp MediaPlayer) RepeatSet(entityId string, serviceData ...map[string]any) 
 }
 
 // Send the media player the command to change sound mode.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (mp MediaPlayer) SelectSoundMode(entityId string, serviceData ...map[string]any) error {
+func (mp MediaPlayer) SelectSoundMode(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "select_sound_mode",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -160,13 +160,13 @@ func (mp MediaPlayer) SelectSoundMode(entityId string, serviceData ...map[string
 }
 
 // Send the media player the command to change input source.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (mp MediaPlayer) SelectSource(entityId string, serviceData ...map[string]any) error {
+func (mp MediaPlayer) SelectSource(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "select_source",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -175,13 +175,13 @@ func (mp MediaPlayer) SelectSource(entityId string, serviceData ...map[string]an
 }
 
 // Set shuffling state.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (mp MediaPlayer) Shuffle(entityId string, serviceData ...map[string]any) error {
+func (mp MediaPlayer) Shuffle(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "shuffle_set",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -190,69 +190,69 @@ func (mp MediaPlayer) Shuffle(entityId string, serviceData ...map[string]any) er
 }
 
 // Toggles a media player power state.
-// Takes an entityId.
-func (mp MediaPlayer) Toggle(entityId string) error {
+// Takes an entityID.
+func (mp MediaPlayer) Toggle(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "toggle",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return mp.api.Call(req)
 }
 
 // Turn a media player power off.
-// Takes an entityId.
-func (mp MediaPlayer) TurnOff(entityId string) error {
+// Takes an entityID.
+func (mp MediaPlayer) TurnOff(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "turn_off",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return mp.api.Call(req)
 }
 
 // Turn a media player power on.
-// Takes an entityId.
-func (mp MediaPlayer) TurnOn(entityId string) error {
+// Takes an entityID.
+func (mp MediaPlayer) TurnOn(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "turn_on",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return mp.api.Call(req)
 }
 
 // Unjoin the player from a group. Only works on
 // platforms with support for player groups.
-// Takes an entityId.
-func (mp MediaPlayer) Unjoin(entityId string) error {
+// Takes an entityID.
+func (mp MediaPlayer) Unjoin(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "unjoin",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return mp.api.Call(req)
 }
 
 // Turn a media player volume down.
-// Takes an entityId.
-func (mp MediaPlayer) VolumeDown(entityId string) error {
+// Takes an entityID.
+func (mp MediaPlayer) VolumeDown(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "volume_down",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return mp.api.Call(req)
 }
 
 // Mute a media player's volume.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (mp MediaPlayer) VolumeMute(entityId string, serviceData ...map[string]any) error {
+func (mp MediaPlayer) VolumeMute(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "volume_mute",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -261,13 +261,13 @@ func (mp MediaPlayer) VolumeMute(entityId string, serviceData ...map[string]any)
 }
 
 // Set a media player's volume level.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (mp MediaPlayer) VolumeSet(entityId string, serviceData ...map[string]any) error {
+func (mp MediaPlayer) VolumeSet(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "volume_set",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -276,12 +276,12 @@ func (mp MediaPlayer) VolumeSet(entityId string, serviceData ...map[string]any) 
 }
 
 // Turn a media player volume up.
-// Takes an entityId.
-func (mp MediaPlayer) VolumeUp(entityId string) error {
+// Takes an entityID.
+func (mp MediaPlayer) VolumeUp(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "media_player",
 		Service: "volume_up",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return mp.api.Call(req)
 }

--- a/internal/services/number.go
+++ b/internal/services/number.go
@@ -4,18 +4,18 @@ type Number struct {
 	api API
 }
 
-func (ib Number) SetValue(entityId string, value float32) error {
+func (ib Number) SetValue(entityID string, value float32) error {
 	req := BaseServiceRequest{
 		Domain:      "number",
 		Service:     "set_value",
 		ServiceData: map[string]any{"value": value},
-		Target:      Entity(entityId),
+		Target:      Entity(entityID),
 	}
 	return ib.api.Call(req)
 }
 
-func (ib Number) MustSetValue(entityId string, value float32) {
-	if err := ib.SetValue(entityId, value); err != nil {
+func (ib Number) MustSetValue(entityID string, value float32) {
+	if err := ib.SetValue(entityID, value); err != nil {
 		panic(err)
 	}
 }

--- a/internal/services/scene.go
+++ b/internal/services/scene.go
@@ -21,13 +21,13 @@ func (s Scene) Apply(serviceData ...map[string]any) error {
 	return s.api.Call(req)
 }
 
-// Create a scene entity. Takes an entityId and an optional
+// Create a scene entity. Takes an entityID and an optional
 // map that is translated into service_data.
-func (s Scene) Create(entityId string, serviceData ...map[string]any) error {
+func (s Scene) Create(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "scene",
 		Service: "create",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -45,13 +45,13 @@ func (s Scene) Reload() error {
 	return s.api.Call(req)
 }
 
-// TurnOn a scene entity. Takes an entityId and an optional
+// TurnOn a scene entity. Takes an entityID and an optional
 // map that is translated into service_data.
-func (s Scene) TurnOn(entityId string, serviceData ...map[string]any) error {
+func (s Scene) TurnOn(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "scene",
 		Service: "turn_on",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]

--- a/internal/services/script.go
+++ b/internal/services/script.go
@@ -9,21 +9,21 @@ type Script struct {
 /* Public API */
 
 // Reload a script that was created in the HA UI.
-func (s Script) Reload(entityId string) error {
+func (s Script) Reload(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "script",
 		Service: "reload",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return s.api.Call(req)
 }
 
 // Toggle a script that was created in the HA UI.
-func (s Script) Toggle(entityId string) error {
+func (s Script) Toggle(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "script",
 		Service: "toggle",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return s.api.Call(req)
 }
@@ -39,11 +39,11 @@ func (s Script) TurnOff() error {
 }
 
 // TurnOn a script that was created in the HA UI.
-func (s Script) TurnOn(entityId string) error {
+func (s Script) TurnOn(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "script",
 		Service: "turn_on",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return s.api.Call(req)
 }

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -36,7 +36,7 @@ func BuildService[
 }
 
 type BaseServiceRequest struct {
-	Id          int64          `json:"id"`
+	ID          int64          `json:"id"`
 	RequestType string         `json:"type"` // must be set to "call_service"
 	Domain      string         `json:"domain"`
 	Service     string         `json:"service"`

--- a/internal/services/switch.go
+++ b/internal/services/switch.go
@@ -8,29 +8,29 @@ type Switch struct {
 
 /* Public API */
 
-func (s Switch) TurnOn(entityId string) error {
+func (s Switch) TurnOn(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "switch",
 		Service: "turn_on",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return s.api.Call(req)
 }
 
-func (s Switch) Toggle(entityId string) error {
+func (s Switch) Toggle(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "switch",
 		Service: "toggle",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return s.api.Call(req)
 }
 
-func (s Switch) TurnOff(entityId string) error {
+func (s Switch) TurnOff(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "switch",
 		Service: "turn_off",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return s.api.Call(req)
 }

--- a/internal/services/timer.go
+++ b/internal/services/timer.go
@@ -9,37 +9,37 @@ type Timer struct {
 /* Public API */
 
 // See https://www.home-assistant.io/integrations/timer/#action-timerstart
-func (t Timer) Start(entityId string, duration string) error {
+func (t Timer) Start(entityID string, duration string) error {
 	req := BaseServiceRequest{
 		Domain:  "timer",
 		Service: "start",
 		ServiceData: map[string]any{
 			"duration": duration,
 		},
-		Target: Entity(entityId),
+		Target: Entity(entityID),
 	}
 	return t.api.Call(req)
 }
 
 // See https://www.home-assistant.io/integrations/timer/#action-timerstart
-func (t Timer) Change(entityId string, duration string) error {
+func (t Timer) Change(entityID string, duration string) error {
 	req := BaseServiceRequest{
 		Domain:  "timer",
 		Service: "change",
 		ServiceData: map[string]any{
 			"duration": duration,
 		},
-		Target: Entity(entityId),
+		Target: Entity(entityID),
 	}
 	return t.api.Call(req)
 }
 
 // See https://www.home-assistant.io/integrations/timer/#action-timerpause
-func (t Timer) Pause(entityId string) error {
+func (t Timer) Pause(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "timer",
 		Service: "pause",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return t.api.Call(req)
 }
@@ -55,11 +55,11 @@ func (t Timer) Cancel() error {
 }
 
 // See https://www.home-assistant.io/integrations/timer/#action-timerfinish
-func (t Timer) Finish(entityId string) error {
+func (t Timer) Finish(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "timer",
 		Service: "finish",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return t.api.Call(req)
 }

--- a/internal/services/tts.go
+++ b/internal/services/tts.go
@@ -19,13 +19,13 @@ func (tts TTS) ClearCache() error {
 }
 
 // Say something using text-to-speech on a media player with cloud.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (tts TTS) CloudSay(entityId string, serviceData ...map[string]any) error {
+func (tts TTS) CloudSay(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "tts",
 		Service: "cloud_say",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -34,13 +34,13 @@ func (tts TTS) CloudSay(entityId string, serviceData ...map[string]any) error {
 }
 
 // Say something using text-to-speech on a media player with google_translate.
-// Takes an entityId and an optional
+// Takes an entityID and an optional
 // map that is translated into service_data.
-func (tts TTS) GoogleTranslateSay(entityId string, serviceData ...map[string]any) error {
+func (tts TTS) GoogleTranslateSay(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "tts",
 		Service: "google_translate_say",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]

--- a/internal/services/vacuum.go
+++ b/internal/services/vacuum.go
@@ -9,56 +9,56 @@ type Vacuum struct {
 /* Public API */
 
 // Tell the vacuum cleaner to do a spot clean-up.
-// Takes an entityId.
-func (v Vacuum) CleanSpot(entityId string) error {
+// Takes an entityID.
+func (v Vacuum) CleanSpot(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "vacuum",
 		Service: "clean_spot",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return v.api.Call(req)
 }
 
 // Locate the vacuum cleaner robot.
-// Takes an entityId.
-func (v Vacuum) Locate(entityId string) error {
+// Takes an entityID.
+func (v Vacuum) Locate(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "vacuum",
 		Service: "locate",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return v.api.Call(req)
 }
 
 // Pause the cleaning task.
-// Takes an entityId.
-func (v Vacuum) Pause(entityId string) error {
+// Takes an entityID.
+func (v Vacuum) Pause(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "vacuum",
 		Service: "pause",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return v.api.Call(req)
 }
 
 // Tell the vacuum cleaner to return to its dock.
-// Takes an entityId.
-func (v Vacuum) ReturnToBase(entityId string) error {
+// Takes an entityID.
+func (v Vacuum) ReturnToBase(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "vacuum",
 		Service: "return_to_base",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return v.api.Call(req)
 }
 
-// Send a raw command to the vacuum cleaner. Takes an entityId and an optional
+// Send a raw command to the vacuum cleaner. Takes an entityID and an optional
 // map that is translated into service_data.
-func (v Vacuum) SendCommand(entityId string, serviceData ...map[string]any) error {
+func (v Vacuum) SendCommand(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "vacuum",
 		Service: "send_command",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -67,13 +67,13 @@ func (v Vacuum) SendCommand(entityId string, serviceData ...map[string]any) erro
 	return v.api.Call(req)
 }
 
-// Set the fan speed of the vacuum cleaner. Takes an entityId and an optional
+// Set the fan speed of the vacuum cleaner. Takes an entityID and an optional
 // map that is translated into service_data.
-func (v Vacuum) SetFanSpeed(entityId string, serviceData ...map[string]any) error {
+func (v Vacuum) SetFanSpeed(entityID string, serviceData ...map[string]any) error {
 	req := BaseServiceRequest{
 		Domain:  "vacuum",
 		Service: "set_fan_speed",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	if len(serviceData) != 0 {
 		req.ServiceData = serviceData[0]
@@ -83,56 +83,56 @@ func (v Vacuum) SetFanSpeed(entityId string, serviceData ...map[string]any) erro
 }
 
 // Start or resume the cleaning task.
-// Takes an entityId.
-func (v Vacuum) Start(entityId string) error {
+// Takes an entityID.
+func (v Vacuum) Start(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "vacuum",
 		Service: "start",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return v.api.Call(req)
 }
 
 // Start, pause, or resume the cleaning task.
-// Takes an entityId.
-func (v Vacuum) StartPause(entityId string) error {
+// Takes an entityID.
+func (v Vacuum) StartPause(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "vacuum",
 		Service: "start_pause",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return v.api.Call(req)
 }
 
 // Stop the current cleaning task.
-// Takes an entityId.
-func (v Vacuum) Stop(entityId string) error {
+// Takes an entityID.
+func (v Vacuum) Stop(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "vacuum",
 		Service: "stop",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return v.api.Call(req)
 }
 
 // Stop the current cleaning task and return to home.
-// Takes an entityId.
-func (v Vacuum) TurnOff(entityId string) error {
+// Takes an entityID.
+func (v Vacuum) TurnOff(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "vacuum",
 		Service: "turn_off",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return v.api.Call(req)
 }
 
 // Start a new cleaning task.
-// Takes an entityId.
-func (v Vacuum) TurnOn(entityId string) error {
+// Takes an entityID.
+func (v Vacuum) TurnOn(entityID string) error {
 	req := BaseServiceRequest{
 		Domain:  "vacuum",
 		Service: "turn_on",
-		Target:  Entity(entityId),
+		Target:  Entity(entityID),
 	}
 	return v.api.Call(req)
 }

--- a/internal/services/zwavejs.go
+++ b/internal/services/zwavejs.go
@@ -9,7 +9,7 @@ type ZWaveJS struct {
 /* Public API */
 
 // ZWaveJS bulk_set_partial_config_parameters service.
-func (zw ZWaveJS) BulkSetPartialConfigParam(entityId string, parameter int, value any) error {
+func (zw ZWaveJS) BulkSetPartialConfigParam(entityID string, parameter int, value any) error {
 	req := BaseServiceRequest{
 		Domain:  "zwave_js",
 		Service: "bulk_set_partial_config_parameters",
@@ -17,7 +17,7 @@ func (zw ZWaveJS) BulkSetPartialConfigParam(entityId string, parameter int, valu
 			"parameter": parameter,
 			"value":     value,
 		},
-		Target: Entity(entityId),
+		Target: Entity(entityID),
 	}
 	return zw.api.Call(req)
 }

--- a/internal/websocket/reader.go
+++ b/internal/websocket/reader.go
@@ -7,13 +7,13 @@ import (
 
 type BaseMessage struct {
 	Type    string `json:"type"`
-	Id      int64  `json:"id"`
+	ID      int64  `json:"id"`
 	Success bool   `json:"success"`
 }
 
 type ChanMsg struct {
 	Type    string
-	Id      int64
+	ID      int64
 	Success bool
 	Raw     []byte
 }
@@ -45,14 +45,14 @@ func (conn *Conn) Run() error {
 		}
 		chanMsg := ChanMsg{
 			Type:    base.Type,
-			Id:      base.Id,
+			ID:      base.ID,
 			Success: base.Success,
 			Raw:     bytes,
 		}
 
 		// If a subscriber has been registered for this message ID,
 		// then call it, too:
-		if subr, ok := conn.getSubscriber(base.Id); ok {
+		if subr, ok := conn.getSubscriber(base.ID); ok {
 			subr(chanMsg)
 		}
 	}

--- a/internal/websocket/subscriptions.go
+++ b/internal/websocket/subscriptions.go
@@ -35,7 +35,7 @@ func (conn *Conn) getSubscriber(messageID int64) (Subscriber, bool) {
 }
 
 type SubEvent struct {
-	Id        int64  `json:"id"`
+	ID        int64  `json:"id"`
 	Type      string `json:"type"`
 	EventType string `json:"event_type"`
 }
@@ -46,7 +46,7 @@ func (conn *Conn) SubscribeToEventType(eventType string, subr Subscriber) Subscr
 		func(lc LockedConn) error {
 			subn = lc.Subscribe(subr)
 			e := SubEvent{
-				Id:        subn.messageID,
+				ID:        subn.messageID,
 				Type:      "subscribe_events",
 				EventType: eventType,
 			}

--- a/interval.go
+++ b/interval.go
@@ -110,15 +110,15 @@ func (ib intervalBuilderEnd) ExceptionRange(start, end time.Time) intervalBuilde
 }
 
 /*
-Enable this interval only when the current state of {entityId} matches {state}.
+Enable this interval only when the current state of {entityID} matches {state}.
 If there is a network error while retrieving state, the interval runs if {runOnNetworkError} is true.
 */
-func (ib intervalBuilderEnd) EnabledWhen(entityId, state string, runOnNetworkError bool) intervalBuilderEnd {
-	if entityId == "" {
-		panic(fmt.Sprintf("entityId is empty in EnabledWhen entityId='%s' state='%s'", entityId, state))
+func (ib intervalBuilderEnd) EnabledWhen(entityID, state string, runOnNetworkError bool) intervalBuilderEnd {
+	if entityID == "" {
+		panic(fmt.Sprintf("entityID is empty in EnabledWhen entityID='%s' state='%s'", entityID, state))
 	}
 	i := internal.EnabledDisabledInfo{
-		Entity:     entityId,
+		Entity:     entityID,
 		State:      state,
 		RunOnError: runOnNetworkError,
 	}
@@ -127,15 +127,15 @@ func (ib intervalBuilderEnd) EnabledWhen(entityId, state string, runOnNetworkErr
 }
 
 /*
-Disable this interval when the current state of {entityId} matches {state}.
+Disable this interval when the current state of {entityID} matches {state}.
 If there is a network error while retrieving state, the interval runs if {runOnNetworkError} is true.
 */
-func (ib intervalBuilderEnd) DisabledWhen(entityId, state string, runOnNetworkError bool) intervalBuilderEnd {
-	if entityId == "" {
-		panic(fmt.Sprintf("entityId is empty in EnabledWhen entityId='%s' state='%s'", entityId, state))
+func (ib intervalBuilderEnd) DisabledWhen(entityID, state string, runOnNetworkError bool) intervalBuilderEnd {
+	if entityID == "" {
+		panic(fmt.Sprintf("entityID is empty in EnabledWhen entityID='%s' state='%s'", entityID, state))
 	}
 	i := internal.EnabledDisabledInfo{
-		Entity:     entityId,
+		Entity:     entityID,
 		State:      state,
 		RunOnError: runOnNetworkError,
 	}

--- a/schedule.go
+++ b/schedule.go
@@ -116,15 +116,15 @@ func (sb scheduleBuilderEnd) OnlyOnDates(t time.Time, tl ...time.Time) scheduleB
 }
 
 /*
-Enable this schedule only when the current state of {entityId} matches {state}.
+Enable this schedule only when the current state of {entityID} matches {state}.
 If there is a network error while retrieving state, the schedule runs if {runOnNetworkError} is true.
 */
-func (sb scheduleBuilderEnd) EnabledWhen(entityId, state string, runOnNetworkError bool) scheduleBuilderEnd {
-	if entityId == "" {
-		panic(fmt.Sprintf("entityId is empty in EnabledWhen entityId='%s' state='%s'", entityId, state))
+func (sb scheduleBuilderEnd) EnabledWhen(entityID, state string, runOnNetworkError bool) scheduleBuilderEnd {
+	if entityID == "" {
+		panic(fmt.Sprintf("entityID is empty in EnabledWhen entityID='%s' state='%s'", entityID, state))
 	}
 	i := internal.EnabledDisabledInfo{
-		Entity:     entityId,
+		Entity:     entityID,
 		State:      state,
 		RunOnError: runOnNetworkError,
 	}
@@ -133,15 +133,15 @@ func (sb scheduleBuilderEnd) EnabledWhen(entityId, state string, runOnNetworkErr
 }
 
 /*
-Disable this schedule when the current state of {entityId} matches {state}.
+Disable this schedule when the current state of {entityID} matches {state}.
 If there is a network error while retrieving state, the schedule runs if {runOnNetworkError} is true.
 */
-func (sb scheduleBuilderEnd) DisabledWhen(entityId, state string, runOnNetworkError bool) scheduleBuilderEnd {
-	if entityId == "" {
-		panic(fmt.Sprintf("entityId is empty in EnabledWhen entityId='%s' state='%s'", entityId, state))
+func (sb scheduleBuilderEnd) DisabledWhen(entityID, state string, runOnNetworkError bool) scheduleBuilderEnd {
+	if entityID == "" {
+		panic(fmt.Sprintf("entityID is empty in EnabledWhen entityID='%s' state='%s'", entityID, state))
 	}
 	i := internal.EnabledDisabledInfo{
-		Entity:     entityId,
+		Entity:     entityID,
 		State:      state,
 		RunOnError: runOnNetworkError,
 	}

--- a/state.go
+++ b/state.go
@@ -17,8 +17,8 @@ type State interface {
 	AfterSunset(...DurationString) bool
 	BeforeSunset(...DurationString) bool
 	ListEntities() ([]EntityState, error)
-	Get(entityId string) (EntityState, error)
-	Equals(entityId, state string) (bool, error)
+	Get(entityID string) (EntityState, error)
+	Equals(entityID, state string) (bool, error)
 }
 
 // State is used to retrieve state from Home Assistant.
@@ -35,42 +35,42 @@ type EntityState struct {
 	LastChanged time.Time      `json:"last_changed"`
 }
 
-func newState(c *http.HttpClient, homeZoneEntityId string) (*StateImpl, error) {
+func newState(c *http.HttpClient, homeZoneEntityID string) (*StateImpl, error) {
 	state := &StateImpl{httpClient: c}
 
 	// Ensure the zone exists and has required attributes
-	entity, err := state.Get(homeZoneEntityId)
+	entity, err := state.Get(homeZoneEntityID)
 	if err != nil {
-		return nil, fmt.Errorf("home zone entity '%s' not found: %w", homeZoneEntityId, err)
+		return nil, fmt.Errorf("home zone entity '%s' not found: %w", homeZoneEntityID, err)
 	}
 
 	// Ensure it's a zone entity
-	if !strings.HasPrefix(homeZoneEntityId, "zone.") {
-		return nil, fmt.Errorf("entity '%s' is not a zone entity (must start with zone.)", homeZoneEntityId)
+	if !strings.HasPrefix(homeZoneEntityID, "zone.") {
+		return nil, fmt.Errorf("entity '%s' is not a zone entity (must start with zone.)", homeZoneEntityID)
 	}
 
 	// Verify and extract latitude and longitude
 	if entity.Attributes == nil {
-		return nil, fmt.Errorf("home zone entity '%s' has no attributes", homeZoneEntityId)
+		return nil, fmt.Errorf("home zone entity '%s' has no attributes", homeZoneEntityID)
 	}
 
 	if lat, ok := entity.Attributes["latitude"].(float64); ok {
 		state.latitude = lat
 	} else {
-		return nil, fmt.Errorf("home zone entity '%s' missing valid latitude attribute", homeZoneEntityId)
+		return nil, fmt.Errorf("home zone entity '%s' missing valid latitude attribute", homeZoneEntityID)
 	}
 
 	if long, ok := entity.Attributes["longitude"].(float64); ok {
 		state.longitude = long
 	} else {
-		return nil, fmt.Errorf("home zone entity '%s' missing valid longitude attribute", homeZoneEntityId)
+		return nil, fmt.Errorf("home zone entity '%s' missing valid longitude attribute", homeZoneEntityID)
 	}
 
 	return state, nil
 }
 
-func (s *StateImpl) Get(entityId string) (EntityState, error) {
-	resp, err := s.httpClient.GetState(entityId)
+func (s *StateImpl) Get(entityID string) (EntityState, error) {
+	resp, err := s.httpClient.GetState(entityID)
 	if err != nil {
 		return EntityState{}, err
 	}
@@ -91,8 +91,8 @@ func (s *StateImpl) ListEntities() ([]EntityState, error) {
 	return es, err
 }
 
-func (s *StateImpl) Equals(entityId string, expectedState string) (bool, error) {
-	currentState, err := s.Get(entityId)
+func (s *StateImpl) Equals(entityID string, expectedState string) (bool, error) {
+	currentState, err := s.Get(entityID)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Go uses the convention that initialisms should be in all-caps, including specifically that "ID" should be capitalized as shown rather than as "Id". See for example:

* https://google.github.io/styleguide/go/decisions#initialisms
* https://go.dev/wiki/CodeReviewComments#initialisms

This PR converts Gome-Assistant to adhere to this convention, which makes it more consistent with other projects and will make it easier for Go programmers to guess the names of identifiers without looking them up. As far as I could determine, I changed it in all of the places, including documentation.

@saml-dev: I realize that this introduces a bunch of churn, so maybe you would rather live with the inconsistency than merge this (textually) big change. Either way, it would be great if you would decide promptly, since future patches based on this one will have annoying conflicts if this PR is rejected.
