### PR TITLE
feat: add friendly name comments to generated entities

### DIFF
--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -29,8 +29,9 @@ type Domain struct {
 }
 
 type Entity struct {
-	FieldName string
-	EntityID  string
+	FieldName    string
+	EntityID     string
+	FriendlyName string
 }
 
 func toFieldName(entityID string) string {
@@ -171,9 +172,16 @@ func generate(ctx context.Context, config Config) error {
 			}
 		}
 
+		// Extract friendly name
+		friendlyName := ""
+		if fn, ok := entity.Attributes["friendly_name"].(string); ok {
+			friendlyName = fn
+		}
+
 		domainMap[domain].Entities = append(domainMap[domain].Entities, Entity{
-			FieldName: toFieldName(entity.EntityID),
-			EntityID:  entity.EntityID,
+			FieldName:    toFieldName(entity.EntityID),
+			EntityID:     entity.EntityID,
+			FriendlyName: friendlyName,
 		})
 	}
 
@@ -184,8 +192,7 @@ func generate(ctx context.Context, config Config) error {
 	}
 
 	// Create entities directory if it doesn't exist
-	err = os.MkdirAll("entities", 0755)
-	if err != nil {
+	if err := os.MkdirAll("entities", 0755); err != nil {
 		return fmt.Errorf("failed to create entities directory: %w", err)
 	}
 
@@ -196,7 +203,7 @@ package entities
 {{ range .Domains }}
 type {{ .Name }}Domain struct {
 	{{- range .Entities }}
-	{{ .FieldName }} string
+	{{ .FieldName }} string{{ if .FriendlyName }} // {{ .FriendlyName }}{{ end }}
 	{{- end }}
 }
 


### PR DESCRIPTION
This PR enhances the entity generation process by adding the entity's `friendly_name` as a comment at the end of each field line in the generated [entities.go](cci:7://file:///d:/Code/smarthome/go/internal/entities/entities.go:0:0-0:0) file.

This metadata is extremely useful for developers to quickly identify the corresponding physical device or logical entity without needing to cross-reference with the Home Assistant dashboard or query the API at runtime.

**Example Output:**

```go
type LightDomain struct {
    LivingRoomLight string // Living Room Main Light
    KitchenLight    string // Kitchen Ceiling Light
}
```

The changes are backward compatible as they only affect code comments.