### PR TITLE
docs: clarify friendly name comments in generated entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,15 @@ entities.Climate.Bedroom
 entities.MediaPlayer.TVRoom
 ```
 
-The constants are based on the entity ID itself, not the name of the entity in Home Assistant.
+The generated identifiers and values are based on entity IDs. However, entity IDs produced by some integrations are not always easy to read or recognize. When available, the generator includes each entity's Home Assistant `friendly_name` as an inline comment:
+
+```go
+type NumberDomain struct {
+	XiaomiCn718205484Oh4wVolumeP21 string // Cute Screen Speaker Volume
+}
+```
+
+Although the generated identifier may not be immediately recognizable, the comment makes the entity's purpose clear at a glance.
 
 ### Write your automations
 


### PR DESCRIPTION
## Summary

This PR updates the entity generator documentation to mention that generated fields include the entity's Home Assistant `friendly_name` as an inline comment when available.

It also adds an example showing how the comment can help identify an entity whose generated ID is not immediately readable.

## Motivation

The existing documentation correctly explains that generated fields are based on entity IDs. However, IDs produced by some integrations can be quite long and difficult to recognize at a glance.

The `friendly_name` comments added in #50 provide useful human-readable context directly in the generated code. Documenting this behavior may help reduce confusion when users browse generated entities or use IDE autocomplete.

This is a documentation-only change and does not affect the generator's behavior.

I think this small clarification could make the feature easier to discover, but I completely understand if you prefer to keep the current documentation unchanged or decide not to merge it.
