### PR TITLE
Expose public service API types

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,21 @@ _, err = service.Light.TurnOff(ctx, ga.Areas("kitchen"))
 _, err = service.Light.TurnOff(ctx, ga.Devices("abc123"))
 ```
 
+For services without a convenience method, use the public `services` package
+to construct a raw request:
+
+```go
+import "saml.dev/gome-assistant/services"
+
+var result any
+err := app.Call(ctx, services.BaseServiceRequest{
+	Domain:      "light",
+	Service:     "turn_on",
+	Target:      services.Entities("light.kitchen"),
+	ServiceData: map[string]any{"brightness_pct": 50},
+}, &result)
+```
+
 ### Interval
 
 Intervals are used to run a function on an interval.

--- a/call.go
+++ b/call.go
@@ -4,18 +4,20 @@ import (
 	"context"
 	"sync"
 
-	"saml.dev/gome-assistant/internal/services"
+	internalservices "saml.dev/gome-assistant/internal/services"
+	"saml.dev/gome-assistant/services"
 	"saml.dev/gome-assistant/websocket"
 )
 
-// CallAndForget implements [services.API.CallAndForget].
+// CallAndForget sends a Home Assistant service request without waiting for its
+// result.
 func (app *App) CallAndForget(req services.BaseServiceRequest) error {
 	conn, err := app.activeConn()
 	if err != nil {
 		return err
 	}
 
-	reqMsg := services.CallServiceMessage{
+	reqMsg := internalservices.CallServiceMessage{
 		BaseMessage: websocket.BaseMessage{
 			Type: "call_service",
 		},
@@ -30,7 +32,8 @@ func (app *App) CallAndForget(req services.BaseServiceRequest) error {
 	)
 }
 
-// Call implements [services.API.Call].
+// Call sends a Home Assistant service request and unmarshals its result into
+// result.
 func (app *App) Call(
 	ctx context.Context, req services.BaseServiceRequest, result any,
 ) error {
@@ -61,7 +64,7 @@ func (app *App) Call(
 	//  5. Unsubscribe from ID.
 	//  6. Unmarshal the "result" part of the response into `result`.
 
-	reqMsg := services.CallServiceMessage{
+	reqMsg := internalservices.CallServiceMessage{
 		BaseMessage: websocket.BaseMessage{
 			Type: "call_service",
 		},

--- a/public_api_test.go
+++ b/public_api_test.go
@@ -1,0 +1,32 @@
+package gomeassistant_test
+
+import (
+	"context"
+	"testing"
+
+	ga "saml.dev/gome-assistant"
+	"saml.dev/gome-assistant/services"
+)
+
+func TestServiceAPIUsesPubliclyNameableTypes(t *testing.T) {
+	request := services.BaseServiceRequest{
+		Domain:  "light",
+		Service: "turn_on",
+		Target:  services.Entities("light.kitchen"),
+	}
+
+	var target ga.Target = request.Target
+	var light *services.Light = (&ga.Service{}).Light
+	var call func(*ga.App, context.Context, services.BaseServiceRequest, any) error = (*ga.App).Call
+	var callAndForget func(*ga.App, services.BaseServiceRequest) error = (*ga.App).CallAndForget
+
+	if len(target.EntityIDs) != 1 || target.EntityIDs[0] != "light.kitchen" {
+		t.Fatalf("unexpected target: %#v", target)
+	}
+	if light != nil {
+		t.Fatal("zero Service unexpectedly contains a Light service")
+	}
+	if call == nil || callAndForget == nil {
+		t.Fatal("service call methods are unavailable")
+	}
+}

--- a/service.go
+++ b/service.go
@@ -1,7 +1,8 @@
 package gomeassistant
 
 import (
-	"saml.dev/gome-assistant/internal/services"
+	internalservices "saml.dev/gome-assistant/internal/services"
+	"saml.dev/gome-assistant/services"
 )
 
 type Service struct {
@@ -32,28 +33,28 @@ type Service struct {
 
 func newService(app *App) *Service {
 	return &Service{
-		AdaptiveLighting:  services.BuildService[services.AdaptiveLighting](app),
-		AlarmControlPanel: services.BuildService[services.AlarmControlPanel](app),
-		Climate:           services.BuildService[services.Climate](app),
-		Cover:             services.BuildService[services.Cover](app),
-		Light:             services.BuildService[services.Light](app),
-		HomeAssistant:     services.BuildService[services.HomeAssistant](app),
-		Lock:              services.BuildService[services.Lock](app),
-		MediaPlayer:       services.BuildService[services.MediaPlayer](app),
-		Switch:            services.BuildService[services.Switch](app),
-		InputBoolean:      services.BuildService[services.InputBoolean](app),
-		InputButton:       services.BuildService[services.InputButton](app),
-		InputText:         services.BuildService[services.InputText](app),
-		InputDatetime:     services.BuildService[services.InputDatetime](app),
-		InputNumber:       services.BuildService[services.InputNumber](app),
-		Event:             services.BuildService[services.Event](app),
-		Notify:            services.BuildService[services.Notify](app),
-		Number:            services.BuildService[services.Number](app),
-		Scene:             services.BuildService[services.Scene](app),
-		Script:            services.BuildService[services.Script](app),
-		Timer:             services.BuildService[services.Timer](app),
-		TTS:               services.BuildService[services.TTS](app),
-		Vacuum:            services.BuildService[services.Vacuum](app),
-		ZWaveJS:           services.BuildService[services.ZWaveJS](app),
+		AdaptiveLighting:  internalservices.BuildService[internalservices.AdaptiveLighting](app),
+		AlarmControlPanel: internalservices.BuildService[internalservices.AlarmControlPanel](app),
+		Climate:           internalservices.BuildService[internalservices.Climate](app),
+		Cover:             internalservices.BuildService[internalservices.Cover](app),
+		Light:             internalservices.BuildService[internalservices.Light](app),
+		HomeAssistant:     internalservices.BuildService[internalservices.HomeAssistant](app),
+		Lock:              internalservices.BuildService[internalservices.Lock](app),
+		MediaPlayer:       internalservices.BuildService[internalservices.MediaPlayer](app),
+		Switch:            internalservices.BuildService[internalservices.Switch](app),
+		InputBoolean:      internalservices.BuildService[internalservices.InputBoolean](app),
+		InputButton:       internalservices.BuildService[internalservices.InputButton](app),
+		InputText:         internalservices.BuildService[internalservices.InputText](app),
+		InputDatetime:     internalservices.BuildService[internalservices.InputDatetime](app),
+		InputNumber:       internalservices.BuildService[internalservices.InputNumber](app),
+		Event:             internalservices.BuildService[internalservices.Event](app),
+		Notify:            internalservices.BuildService[internalservices.Notify](app),
+		Number:            internalservices.BuildService[internalservices.Number](app),
+		Scene:             internalservices.BuildService[internalservices.Scene](app),
+		Script:            internalservices.BuildService[internalservices.Script](app),
+		Timer:             internalservices.BuildService[internalservices.Timer](app),
+		TTS:               internalservices.BuildService[internalservices.TTS](app),
+		Vacuum:            internalservices.BuildService[internalservices.Vacuum](app),
+		ZWaveJS:           internalservices.BuildService[internalservices.ZWaveJS](app),
 	}
 }

--- a/services/services.go
+++ b/services/services.go
@@ -1,0 +1,53 @@
+// Package services contains the public types used to call Home Assistant
+// services.
+package services
+
+import internalservices "saml.dev/gome-assistant/internal/services"
+
+// BaseServiceRequest contains the fields needed to call a Home Assistant
+// service. ServiceData may contain any JSON-serializable value accepted by the
+// service.
+type BaseServiceRequest = internalservices.BaseServiceRequest
+
+// Target identifies the entities, areas, or devices affected by a service
+// call.
+type Target = internalservices.Target
+
+type AdaptiveLighting = internalservices.AdaptiveLighting
+type AlarmControlPanel = internalservices.AlarmControlPanel
+type Climate = internalservices.Climate
+type Cover = internalservices.Cover
+type Event = internalservices.Event
+type HomeAssistant = internalservices.HomeAssistant
+type InputBoolean = internalservices.InputBoolean
+type InputButton = internalservices.InputButton
+type InputDatetime = internalservices.InputDatetime
+type InputNumber = internalservices.InputNumber
+type InputText = internalservices.InputText
+type Light = internalservices.Light
+type Lock = internalservices.Lock
+type MediaPlayer = internalservices.MediaPlayer
+type Notify = internalservices.Notify
+type Number = internalservices.Number
+type Scene = internalservices.Scene
+type Script = internalservices.Script
+type Switch = internalservices.Switch
+type Timer = internalservices.Timer
+type TTS = internalservices.TTS
+type Vacuum = internalservices.Vacuum
+type ZWaveJS = internalservices.ZWaveJS
+
+// Entities returns a target containing the provided entity IDs.
+func Entities(entityIDs ...string) Target {
+	return internalservices.Entities(entityIDs...)
+}
+
+// Areas returns a target containing the provided area IDs.
+func Areas(areaIDs ...string) Target {
+	return internalservices.Areas(areaIDs...)
+}
+
+// Devices returns a target containing the provided device IDs.
+func Devices(deviceIDs ...string) Target {
+	return internalservices.Devices(deviceIDs...)
+}

--- a/target.go
+++ b/target.go
@@ -1,7 +1,7 @@
 package gomeassistant
 
 import (
-	"saml.dev/gome-assistant/internal/services"
+	"saml.dev/gome-assistant/services"
 )
 
 type Target = services.Target


### PR DESCRIPTION
## Summary

- add a public `services` package for service, request, and target types
- update exported root APIs so their signatures no longer expose `internal/services`
- document raw service calls and cover the boundary from an external test package

The implementation remains internal, while downstream consumers can now name service types and construct `BaseServiceRequest` values without importing an inaccessible package.

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- built a separate external consumer module against the local checkout